### PR TITLE
commit and push instead of PR

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -35,15 +35,12 @@ jobs:
         run: |
           git diff --quiet README.md || echo "changes=true" >> $GITHUB_OUTPUT
 
-      - name: Create Pull Request
+      - name: Commit and push changes
         if: steps.git-check.outputs.changes == 'true'
-        uses: peter-evans/create-pull-request@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Auto-update README from JSON [skip ci]"
-          title: "Auto-update README from JSON"
-          body: "Automated README update from JSON data"
-          branch: "update-readme"
-          base: "main" # Target branch (defaults to default branch if omitted)
-          delete-branch: true # Automatically delete the branch after merge
-          labels: "automated" # Optional: Add labels to the PR
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "Auto-update README from JSON [skip ci]" || echo "No changes to commit"
+          git push origin HEAD:main
+


### PR DESCRIPTION
Change GitHub action so it only commits and pushes the changes in README after running Python script instead of new PR.

The script is run automatically whenever JSON or the script is changed