### PR TITLE
deploy when changes to README.md

### DIFF
--- a/.github/workflows/page_deploy.yml
+++ b/.github/workflows/page_deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  workflow_run:
+    workflows: ["Update README from JSON"]
+    branches: [main] 
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout (main branch)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Deploy the site only when changes to README.md are made in the main branch. This limits unnecessary builds and new deployments

For this to take effects and disable automatic page builds, the repo page setting must be changed to the following
setting >> Pages >> Build and deployment [source] = GitHub Actions


![image](https://github.com/user-attachments/assets/3558de63-3c0e-4c47-abbd-fe3682d1c025)
